### PR TITLE
chore: stop using Che plugin registry for editor definitions

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -1,0 +1,36 @@
+schemaVersion: 2.3.0
+metadata:
+  name: devworkspace-generator
+components:
+  - name: builder
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
+      memoryRequest: 256Mi
+      memoryLimit: 3Gi
+      cpuRequest: 100m
+      cpuLimit: '1'
+commands:
+  - id: build
+    exec:
+      label: "1. Build"
+      component: builder
+      workingDir: ${PROJECTS_ROOT}/devworkspace-generator
+      commandLine: yarn && yarn format:fix && yarn build
+  - id: test
+    exec:
+      label: "2. Run tests"
+      component: builder
+      workingDir: ${PROJECTS_ROOT}/devworkspace-generator
+      commandLine: yarn test
+  - id: generate-devworkspace
+    exec:
+      label: "3. Generate DevWorkspace with Template"
+      component: builder
+      workingDir: ${PROJECTS_ROOT}/devworkspace-generator
+      commandLine: |
+        node lib/entrypoint.js \
+        --devfile-url:https://github.com/che-samples/java-spring-petclinic/tree/main \
+        --editor-url:https://raw.githubusercontent.com/eclipse-che/che-operator/refs/heads/main/editors-definitions/che-code-insiders.yaml \
+        --output-file:/tmp/devworkspace-che-code-latest.yaml \
+        --injectDefaultComponent:true \
+        --defaultComponentImage:registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "redhat.vscode-yaml",
+        "Orta.vscode-jest",
+        "cnshenj.vscode-task-manager"
+    ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,51 @@
 ## DevWorkspace Generator
-The library is used by Devfile registry component to generate the DevWorkspace components and DevWorkspace templates. It requires editor definitions from the 
-[che-plugin-registry](https://github.com/eclipse-che/che-plugin-registry/).
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com#https://github.com/devfile/devworkspace-generator)
+[![Contribute (nightly)](https://img.shields.io/static/v1?label=nightly%20Che&message=for%20maintainers&logo=eclipseche&color=FDB940&labelColor=525C86)](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com#https://github.com/devfile/devworkspace-generator)
 
-## How to use the library
-The library can be used as a standalone library.
+The library is used by Eclipse Che to generate DevWorkspace components and templates. It requires both the original devfile.yaml and the editor definitions.
+
+## Where is it Published?
+This library is available on npm.
+
+You can find the published package here: \
+__npm:__ [@eclipse-che/che-devworkspace-generator](https://www.npmjs.com/package/@eclipse-che/che-devworkspace-generator)
+
+## Usage
+
+### Here’s an example of how to use the @eclipse-che/che-devworkspace-generator library to generate a DevWorkspace and DevWorkspaceTemplate:
+
+```typescript
+import { Main as DevworkspaceGenerator } from '@eclipse-che/che-devworkspace-generator/lib/main';
+import { V1alpha2DevWorkspaceTemplate } from '@devfile/api';
+import { dump } from 'js-yaml';
+
+// Initialize the DevWorkspace generator
+const generator = new DevworkspaceGenerator();
+
+// Example function to generate DevWorkspace resources
+async function generateDevWorkspace(devfileContent: string, editorContent: string, axiosInstance: any) {
+  // Generate the Devfile context
+  const context = await generator.generateDevfileContext(
+    {
+      devfileContent,
+      editorContent,
+      projects: [],
+    },
+    axiosInstance,
+  );
+
+  // Convert templates and DevWorkspace to YAML
+  const allContentArray = context.devWorkspaceTemplates.map(
+    (template: V1alpha2DevWorkspaceTemplate) => dump(template),
+  );
+  allContentArray.push(dump(context.devWorkspace));
+
+  // Return the YAML content joined by "---"
+  return allContentArray.join('---\n');
+}
+```
+
+### The library can be used as a standalone library:
 
 ```
 USAGE
@@ -14,10 +56,11 @@ OPTIONS
             or
       --devfile-path:          path to the devfile.yaml file
 
-      --plugin-registry-url:   URL to the plugin registry that contains editor definitions (devfile.yaml)
-      --editor-entry:          editor ID, found on the <plugin-registry-url>, to resolve the devfile.yaml
+      --editor-url:            URL for the editor's definition, should be publicly accessible for download.
             or
       --editor-path:           local file path of the editor devfile.yaml
+            or
+      --editor-content:        content of the editor devfile.yaml
 
       --output-file:           local file path for the generated devworkspace yaml 
 
@@ -29,12 +72,11 @@ OPTIONS
 
 EXAMPLES
 
-    # online example, using editor definition from https://che-plugin-registry-main.surge.sh/
+    # online example, using editor definition from https://raw.githubusercontent.com/eclipse-che/che-operator/refs/heads/main/editors-definitions/che-code-insiders.yaml
 
     $ node lib/entrypoint.js \
         --devfile-url:https://github.com/che-samples/java-spring-petclinic/tree/main \
-        --plugin-registry-url:https://che-plugin-registry-main.surge.sh/v3/ \
-        --editor-entry:che-incubator/che-code/latest \
+        --editor-url:https://raw.githubusercontent.com/eclipse-che/che-operator/refs/heads/main/editors-definitions/che-code-insiders.yaml \
         --output-file:/tmp/devworkspace-che-code-latest.yaml \
         --injectDefaultComponent:true \
         --defaultComponentImage:registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/src/editor/editor-module.ts
+++ b/src/editor/editor-module.ts
@@ -9,10 +9,10 @@
  ***********************************************************************/
 import { ContainerModule, interfaces } from 'inversify';
 
-import { PluginRegistryResolver } from './plugin-registry-resolver';
+import { EditorResolver } from './editor-resolver';
 
-const pluginRegistryModule = new ContainerModule((bind: interfaces.Bind) => {
-  bind(PluginRegistryResolver).toSelf().inSingletonScope();
+const editorModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind(EditorResolver).toSelf().inSingletonScope();
 });
 
-export { pluginRegistryModule };
+export { editorModule };

--- a/src/editor/editor-resolver.ts
+++ b/src/editor/editor-resolver.ts
@@ -10,7 +10,7 @@
 
 import * as jsYaml from 'js-yaml';
 
-import { inject, injectable, named } from 'inversify';
+import { inject, injectable } from 'inversify';
 
 import { UrlFetcher } from '../fetch/url-fetcher';
 
@@ -18,19 +18,14 @@ import { UrlFetcher } from '../fetch/url-fetcher';
  * Resolve plug-ins by grabbing the definition from the plug-in registry.
  */
 @injectable()
-export class PluginRegistryResolver {
-  @inject('string')
-  @named('PLUGIN_REGISTRY_URL')
-  private pluginRegistryUrl: string;
-
+export class EditorResolver {
   @inject(UrlFetcher)
   private urlFetcher: UrlFetcher;
 
-  // FQN id (like che-incubator/che-code/next)
+  // Editor URL (like https://raw.githubusercontent.com/eclipse-che/che-operator/refs/heads/main/editors-definitions/che-code-latest.yaml)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async loadDevfilePlugin(devfileId: string): Promise<any> {
-    const devfileUrl = `${this.pluginRegistryUrl}/plugins/${devfileId}/devfile.yaml`;
-    const devfileContent = await this.urlFetcher.fetchText(devfileUrl);
+  async loadEditor(editorUrl: string): Promise<any> {
+    const devfileContent = await this.urlFetcher.fetchText(editorUrl);
     return jsYaml.load(devfileContent);
   }
 }

--- a/src/inversify/inversify-binding.ts
+++ b/src/inversify/inversify-binding.ts
@@ -15,7 +15,7 @@ import { devfileModule } from '../devfile/devfile-module';
 import { fetchModule } from '../fetch/fetch-module';
 import { githubModule } from '../github/github-module';
 import { resolveModule } from '../resolve/resolve-module';
-import { pluginRegistryModule } from '../plugin-registry/plugin-registry-module';
+import { editorModule } from '../editor/editor-module';
 import { devfileSchemaModule } from '../devfile-schema/devfile-schema-module';
 import { bitbucketModule } from '../bitbucket/bitbucket-module';
 import { bitbucketServerModule } from '../bitbucket-server/bitbucket-server-module';
@@ -35,11 +35,10 @@ export class InversifyBinding {
     this.container.load(bitbucketModule);
     this.container.load(bitbucketServerModule);
     this.container.load(resolveModule);
-    this.container.load(pluginRegistryModule);
+    this.container.load(editorModule);
     this.container.load(devfileSchemaModule);
 
     this.container.bind(Symbol.for('AxiosInstance')).toConstantValue(options.axiosInstance);
-    this.container.bind('string').toConstantValue(options.pluginRegistryUrl).whenTargetNamed('PLUGIN_REGISTRY_URL');
 
     return this.container;
   }
@@ -49,6 +48,5 @@ export class InversifyBinding {
  * Options for inversify bindings
  */
 export interface InversifyBindingOptions {
-  pluginRegistryUrl: string;
   axiosInstance: AxiosInstance;
 }

--- a/tests/editor/editor-resolver.spec.ts
+++ b/tests/editor/editor-resolver.spec.ts
@@ -13,10 +13,10 @@ import 'reflect-metadata';
 import * as jsYaml from 'js-yaml';
 
 import { Container } from 'inversify';
-import { PluginRegistryResolver } from '../../src/plugin-registry/plugin-registry-resolver';
+import { EditorResolver } from '../../src/editor/editor-resolver';
 import { UrlFetcher } from '../../src/fetch/url-fetcher';
 
-describe('Test PluginRegistryResolver', () => {
+describe('Test EditorResolver', () => {
   let container: Container;
 
   const originalConsoleError = console.error;
@@ -29,16 +29,15 @@ describe('Test PluginRegistryResolver', () => {
     fetchTextOptionalContent: urlFetcherFetchTextOptionalMock,
   } as any;
 
-  let pluginRegistryResolver: PluginRegistryResolver;
+  let editorResolver: EditorResolver;
 
   beforeEach(() => {
     jest.restoreAllMocks();
     jest.resetAllMocks();
     container = new Container();
-    container.bind(PluginRegistryResolver).toSelf().inSingletonScope();
+    container.bind(EditorResolver).toSelf().inSingletonScope();
     container.bind(UrlFetcher).toConstantValue(urlFetcher);
-    container.bind('string').toConstantValue('http://fake-plugin-registry').whenTargetNamed('PLUGIN_REGISTRY_URL');
-    pluginRegistryResolver = container.get(PluginRegistryResolver);
+    editorResolver = container.get(EditorResolver);
     console.error = mockedConsoleError;
   });
 
@@ -46,12 +45,12 @@ describe('Test PluginRegistryResolver', () => {
     console.error = originalConsoleError;
   });
 
-  test('basic loadDevfilePlugin', async () => {
-    const myId = 'foo';
+  test('basic loadEditor', async () => {
+    const myId = 'http://editor.yaml';
     const dummy = { dummyContent: 'dummy' };
     urlFetcherFetchTextMock.mockResolvedValue(jsYaml.dump(dummy));
-    const content = await pluginRegistryResolver.loadDevfilePlugin(myId);
-    expect(urlFetcherFetchTextMock).toBeCalledWith('http://fake-plugin-registry/plugins/foo/devfile.yaml');
+    const content = await editorResolver.loadEditor(myId);
+    expect(urlFetcherFetchTextMock).toBeCalledWith('http://editor.yaml');
     expect(content).toStrictEqual(dummy);
   });
 });

--- a/tests/inversify/inversify-binding.spec.ts
+++ b/tests/inversify/inversify-binding.spec.ts
@@ -17,7 +17,6 @@ import { InversifyBinding, InversifyBindingOptions } from '../../src/inversify/i
 import { Container } from 'inversify';
 import { Generate } from '../../src/generate';
 import { UrlFetcher } from '../../src/fetch/url-fetcher';
-import { PluginRegistryResolver } from '../../src/plugin-registry/plugin-registry-resolver';
 import { DevContainerComponentFinder } from '../../src/devfile/dev-container-component-finder';
 import { TYPES } from '../../src/types';
 import { DevfileSchemaValidator } from '../../src/devfile-schema/devfile-schema-validator';
@@ -39,7 +38,6 @@ describe('Test InversifyBinding', () => {
 
     const axiosInstance = axios.default;
     const options: InversifyBindingOptions = {
-      pluginRegistryUrl: 'http://fake-registry',
       axiosInstance,
     };
 
@@ -56,9 +54,6 @@ describe('Test InversifyBinding', () => {
 
     // check resolve module
     expect(container.getAll(TYPES.Resolver).length).toBe(3);
-
-    // check plugin-registry module
-    expect(container.get(PluginRegistryResolver)).toBeDefined();
 
     // check devfile-schema module
     expect(container.get(DevfileSchemaValidator)).toBeDefined();


### PR DESCRIPTION
### What does this PR do?

- Stop using che-plugin-registry URL to get editor definitions, instead it's possible to provide `editorURL` parameter
- Add .devfile.yaml to develop on Che
- Add LICENSE file
- Update README
- Add default extensions

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23187

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
It could be tested by running it on Che instance using factory: [![Contribute (nightly)](https://img.shields.io/static/v1?label=Click%20Me&message=Dogfooding&logo=eclipseche&color=FDB940&labelColor=525C86)](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com#https://github.com/devfile/devworkspace-generator/tree/sv-remove-plugin-reg)

And execute commands provided by devfile:

- **Build**
- **Generate DevWorkspace with Template** (it uses **editorURL** as a prameter)

As a result **/tmp/devworkspace-che-code-latest.yaml** should be generated
