### PR TITLE
fix: change node version in release workflow

### DIFF
--- a/.github/workflows/devworkspace-generator-release.yml
+++ b/.github/workflows/devworkspace-generator-release.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    name: Create Che Devfile Registry Release
+    name: Create Che Devworkspace Generator Release
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/setup-node@v4
@@ -39,10 +39,6 @@ jobs:
           sudo apt-get update -y || true
           sudo apt-get -y -q install hub
           hub --version
-      - name: Install NodeJS
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.18.0
       - name: Check existing tags
         run: |
           set +e


### PR DESCRIPTION
### What does this PR do?
address the failure of [release workflow](https://github.com/eclipse-che/che-release/actions/runs/11681324861/job/32526146796) by updating the node version (remove the extra setup action, so the node version will be 20 now)

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

