### PR TITLE
chore: update build workflows - new node version and Trusted publishing

### DIFF
--- a/.github/workflows/devworkspace-generator-publish-next.yml
+++ b/.github/workflows/devworkspace-generator-publish-next.yml
@@ -15,13 +15,19 @@ on:
       - main
       - 7.**.x
 
+permissions:
+  id-token: write  # Required for publishing to npmjs
+  contents: write
+  pull-requests: write
+
+
 jobs:
   publish:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
         scope: '@eclipse-che'
     - name: Clone source code
@@ -36,8 +42,6 @@ jobs:
         key: yarn-${{ hashFiles('yarn.lock') }}
         restore-keys: yarn-
     - name: publish
-      env:
-        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       run: |
         if [[ ${GITHUB_REF##*/} == "7."**".x" ]]; then
           echo "[INFO] using ${GITHUB_REF##*/} tag"
@@ -47,7 +51,7 @@ jobs:
           DIST_TAG=next
         fi
 
-        yarn
+        yarn install --frozen-lockfile
         yarn compile
         SHORT_SHA1=$(git rev-parse --short=7 HEAD)
         CURRENT_VERSION=$(jq -r '.version' package.json)

--- a/.github/workflows/devworkspace-generator-release.yml
+++ b/.github/workflows/devworkspace-generator-release.yml
@@ -9,6 +9,11 @@
 
 name: Release Che Devworkspace Generator
 
+permissions:
+  id-token: write  # Required for publishing to npmjs
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -27,11 +32,11 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           scope: '@eclipse-che'
       - name: "Checkout source code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up environment
@@ -68,11 +73,9 @@ jobs:
           restore-keys: yarn-
       - name: Run make-release.sh script
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           GITHUB_TOKEN: ${{secrets.DEVWORKSPACE_GENERATOR_RELEASE_GITHUB_TOKEN}}
         run: |
           git config --global user.name "Anatolii Bazko"
           git config --global user.email "abazko@redhat.com"
           
           ./make-release.sh --version ${{ github.event.inputs.version }}
-

--- a/make-release.sh
+++ b/make-release.sh
@@ -72,7 +72,7 @@ checkoutToNextBranch() {
 publishArtifacts() {
   echo "[INFO] Publish DevWorkspace Generator ${VERSION} artifacts"
 
-  yarn
+  yarn install --frozen-lockfile
   yarn compile
   npm publish --tag latest
 }


### PR DESCRIPTION
### What does this PR do?
- Implement Trusted Publishing
- update Node to 24 version
- ensure yarn files are frozen during installation

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23702

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

