### PR TITLE
ci: add workflow to auto-regenerate licenses for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-license.yml
+++ b/.github/workflows/dependabot-license.yml
@@ -1,0 +1,93 @@
+#
+# Copyright (c) 2022-2026
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: Dependabot License Update
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  update-licenses:
+    runs-on: ubuntu-22.04
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Use Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Regenerate licenses
+        run: |
+          MAX_ATTEMPTS=3
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "=== Attempt $attempt of $MAX_ATTEMPTS ==="
+
+            if yarn license:generate; then
+              echo "License generation succeeded."
+              break
+            fi
+
+            if [ ! -f .deps/problems.md ]; then
+              echo "::error::License generation failed but no problems.md found."
+              exit 1
+            fi
+
+            SECTION=""
+            while IFS= read -r line; do
+              if echo "$line" | grep -q "## UNRESOLVED Production dependencies"; then
+                SECTION="prod"
+              elif echo "$line" | grep -q "## UNRESOLVED Development dependencies"; then
+                SECTION="dev"
+              fi
+
+              PKG=$(echo "$line" | grep -oP '`\K[^`]+' || true)
+              if [ -z "$PKG" ] || [ -z "$SECTION" ]; then
+                continue
+              fi
+
+              EXCLUDED_FILE=".deps/EXCLUDED/${SECTION}.md"
+              if grep -qF "\`${PKG}\`" "$EXCLUDED_FILE" 2>/dev/null; then
+                echo "Already excluded: $PKG"
+                continue
+              fi
+
+              echo "| \`${PKG}\` | transitive dependency |" >> "$EXCLUDED_FILE"
+              echo "Added $PKG to $EXCLUDED_FILE"
+            done < .deps/problems.md
+
+            if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+              echo "::error::Failed to resolve all dependencies after $MAX_ATTEMPTS attempts."
+              exit 1
+            fi
+          done
+
+      - name: Commit and push changes
+        run: |
+          git diff --quiet .deps/ && exit 0
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .deps/
+          git commit -s -m "chore(deps): regenerate license dependencies"
+          git push

--- a/.github/workflows/dependabot-license.yml
+++ b/.github/workflows/dependabot-license.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   update-licenses:
     runs-on: ubuntu-22.04
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Summary

  - Adds a GitHub Actions workflow that automatically regenerates license dependency files for Dependabot PRs
  - Parses unresolved dependencies from .deps/problems.md and adds them to .deps/EXCLUDED/*.md
  - Commits and pushes updated .deps/ files back to the PR branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that regenerates and validates project license data when dependency updates arrive, classifies unresolved production vs development dependencies, updates exclusion lists for problematic packages, and automatically commits license-related documentation changes back to the update pull request to keep license records in sync.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devfile/devworkspace-generator/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->